### PR TITLE
[ConfigTransformer] Add maker-bundle test fixtures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "phpstan/phpstan-symfony": "^0.12.6",
         "phpunit/phpunit": "^8.5|^9.0",
         "rector/rector": "^0.7.47",
+        "symfony/expression-language": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0",
         "symfony/routing": "^4.4|^5.0",
         "symfony/security-bundle": "^4.4|^5.0",

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -8,6 +8,7 @@
         "symfony/dependency-injection": "^4.4|^5.0",
         "symfony/console": "^4.4|^5.0",
         "symfony/http-kernel": "^4.4|^5.0",
+        "symfony/expression-language": "^4.4|^5.0",
         "symfony/yaml": "^4.4|^5.0",
         "nette/neon": "^3.0",
         "nette/utils": "^3.1",

--- a/packages/config-transformer/packages/format-switcher/src/Converter/ConfigFormatConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/Converter/ConfigFormatConverter.php
@@ -14,9 +14,6 @@ use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\Format;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symplify\SmartFileSystem\SmartFileInfo;
 
-/**
- * @see \Migrify\ConfigTransformer\FormatSwitcher\Tests\Converter\ConfigFormatConverter\ConfigFormatConverterTest
- */
 final class ConfigFormatConverter
 {
     /**
@@ -61,7 +58,6 @@ final class ConfigFormatConverter
     public function convert(SmartFileInfo $smartFileInfo, string $inputFormat, string $outputFormat): string
     {
         $containerBuilder = $this->configLoader->createAndLoadContainerBuilderFromFileInfo($smartFileInfo);
-
         if ($outputFormat === Format::YAML) {
             return $this->dumpContainerBuilderToYaml($containerBuilder);
         }

--- a/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
@@ -621,7 +621,7 @@ final class YamlToPhpConverter
             case 'NULL':
                 return 'null';
             default:
-                return $value;
+                return (string) $value;
         }
     }
 

--- a/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
@@ -327,6 +327,7 @@ final class YamlToPhpConverter
                         break;
                     }
                     // no break
+                case 'bind':
                 case 'autowire':
                 case 'autoconfigure':
                     $method = $serviceConfigKey;

--- a/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/Converter/YamlToPhpConverter.php
@@ -8,6 +8,7 @@ use InvalidArgumentException;
 use LogicException;
 use Migrify\ConfigTransformer\FormatSwitcher\Exception\NotImplementedYetException;
 use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\ClosureNodeFactory;
+use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\ImportNodeFactory;
 use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\ParametersPhpNodeFactory;
 use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\PhpNodeFactory;
 use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\ServicesPhpNodeFactory;
@@ -119,6 +120,11 @@ final class YamlToPhpConverter
      */
     private $singleServicePhpNodeFactory;
 
+    /**
+     * @var ImportNodeFactory
+     */
+    private $importNodeFactory;
+
     public function __construct(
         Parser $yamlParser,
         PhpNodeFactory $phpNodeFactory,
@@ -127,6 +133,7 @@ final class YamlToPhpConverter
         ParametersPhpNodeFactory $parametersPhpNodeFactory,
         FluentMethodCallPrinter $fluentMethodCallPrinter,
         SingleServicePhpNodeFactory $singleServicePhpNodeFactory,
+        ImportNodeFactory $importNodeFactory,
         ClassNaming $classNaming
     ) {
         $this->yamlParser = $yamlParser;
@@ -137,6 +144,7 @@ final class YamlToPhpConverter
         $this->parametersPhpNodeFactory = $parametersPhpNodeFactory;
         $this->classNaming = $classNaming;
         $this->singleServicePhpNodeFactory = $singleServicePhpNodeFactory;
+        $this->importNodeFactory = $importNodeFactory;
     }
 
     public function convert(string $yaml): string
@@ -215,7 +223,7 @@ final class YamlToPhpConverter
             if (is_array($import)) {
                 $arguments = $this->sortArgumentsByKeyIfExists($import, [self::RESOURCE, 'type', 'ignore_errors']);
 
-                $methodCall = $this->phpNodeFactory->createImportMethodCall($arguments);
+                $methodCall = $this->importNodeFactory->createImportMethodCall($arguments);
                 $this->addNode($methodCall);
                 continue;
             }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
+
+use PhpParser\BuilderHelpers;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use PhpParser\Node\Scalar\String_;
+
+final class CommonFactory
+{
+    public function createAbsoluteDirExpr($argument): Expr
+    {
+        if (is_string($argument)) {
+            // preslash with dir
+            $argument = '/' . $argument;
+        }
+
+        $argumentValue = BuilderHelpers::normalizeValue($argument);
+
+        if ($argumentValue instanceof String_) {
+            $argumentValue = new Concat(new Dir(), $argumentValue);
+        }
+
+        return $argumentValue;
+    }
+}

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
@@ -4,14 +4,27 @@ declare(strict_types=1);
 
 namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
 
+use Migrify\ConfigTransformer\Naming\ClassNaming;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\BinaryOp\Concat;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\MagicConst\Dir;
 use PhpParser\Node\Scalar\String_;
 
 final class CommonFactory
 {
+    /**
+     * @var ClassNaming
+     */
+    private $classNaming;
+
+    public function __construct(ClassNaming $classNaming)
+    {
+        $this->classNaming = $classNaming;
+    }
+
     public function createAbsoluteDirExpr($argument): Expr
     {
         if (is_string($argument)) {
@@ -26,5 +39,11 @@ final class CommonFactory
         }
 
         return $argumentValue;
+    }
+
+    public function createShortClassReference(string $className): ClassConstFetch
+    {
+        $shortClassName = $this->classNaming->getShortName($className);
+        return new ClassConstFetch(new Name($shortClassName), 'class');
     }
 }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/CommonFactory.php
@@ -44,6 +44,11 @@ final class CommonFactory
     public function createShortClassReference(string $className): ClassConstFetch
     {
         $shortClassName = $this->classNaming->getShortName($className);
-        return new ClassConstFetch(new Name($shortClassName), 'class');
+        return $this->createConstFetch($shortClassName, 'class');
+    }
+
+    public function createConstFetch(string $className, string $constantName): ClassConstFetch
+    {
+        return new ClassConstFetch(new Name($className), $constantName);
     }
 }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ImportNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ImportNodeFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
+
+use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\VariableName;
+use PhpParser\BuilderHelpers;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+
+final class ImportNodeFactory
+{
+    /**
+     * @var CommonFactory
+     */
+    private $commonFactory;
+
+    public function __construct(CommonFactory $commonFactory)
+    {
+        $this->commonFactory = $commonFactory;
+    }
+
+    /**
+     * @param mixed[] $arguments
+     */
+    public function createImportMethodCall(array $arguments): Expression
+    {
+        $containerConfiguratorVariable = new Variable(VariableName::CONTAINER_CONFIGURATOR);
+        $methodCall = new MethodCall($containerConfiguratorVariable, 'import');
+
+        foreach ($arguments as $argument) {
+            if (is_bool($argument) || in_array($argument, ['annotations', 'directory', 'glob'], true)) {
+                $expr = BuilderHelpers::normalizeValue($argument);
+            } else {
+                $expr = $this->commonFactory->createAbsoluteDirExpr($argument);
+            }
+
+            $methodCall->args[] = new Arg($expr);
+        }
+
+        return new Expression($methodCall);
+    }
+}

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/NamespaceFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/NamespaceFactory.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
+
+final class NamespaceFactory
+{
+}

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/PhpNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/PhpNodeFactory.php
@@ -8,11 +8,8 @@ use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\VariableName;
 use PhpParser\BuilderHelpers;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
-use PhpParser\Node\Expr\BinaryOp\Concat;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Scalar\MagicConst\Dir;
-use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt\Expression;
 
 final class PhpNodeFactory
@@ -26,38 +23,6 @@ final class PhpNodeFactory
         $methodCall->args[] = new Arg($parameterValue);
 
         return new Expression($methodCall);
-    }
-
-    /**
-     * @param mixed[] $arguments
-     */
-    public function createImportMethodCall(array $arguments): Expression
-    {
-        $containerConfiguratorVariable = new Variable(VariableName::CONTAINER_CONFIGURATOR);
-        $methodCall = new MethodCall($containerConfiguratorVariable, 'import');
-
-        foreach ($arguments as $argument) {
-            $expr = $this->createAbsoluteDirExpr($argument);
-            $methodCall->args[] = new Arg($expr);
-        }
-
-        return new Expression($methodCall);
-    }
-
-    public function createAbsoluteDirExpr($argument): Expr
-    {
-        if (is_string($argument)) {
-            // preslash with dir
-            $argument = '/' . $argument;
-        }
-
-        $argumentValue = BuilderHelpers::normalizeValue($argument);
-
-        if ($argumentValue instanceof String_) {
-            $argumentValue = new Concat(new Dir(), $argumentValue);
-        }
-
-        return $argumentValue;
     }
 
     private function createParamValue($value): Expr

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ServicesPhpNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ServicesPhpNodeFactory.php
@@ -28,13 +28,13 @@ final class ServicesPhpNodeFactory
     private const EXCLUDE = 'exclude';
 
     /**
-     * @var PhpNodeFactory
+     * @var CommonFactory
      */
-    private $phpNodeFactory;
+    private $commonFactory;
 
-    public function __construct(PhpNodeFactory $phpNodeFactory)
+    public function __construct(CommonFactory $commonFactory)
     {
-        $this->phpNodeFactory = $phpNodeFactory;
+        $this->commonFactory = $commonFactory;
     }
 
     public function createServicesInit(): Expression
@@ -64,7 +64,7 @@ final class ServicesPhpNodeFactory
         }
 
         foreach ($exclude as $key => $singleExclude) {
-            $excludeValue[$key] = $this->phpNodeFactory->createAbsoluteDirExpr($singleExclude);
+            $excludeValue[$key] = $this->commonFactory->createAbsoluteDirExpr($singleExclude);
         }
 
         $excludeValue = BuilderHelpers::normalizeValue($excludeValue);
@@ -101,7 +101,7 @@ final class ServicesPhpNodeFactory
 
         $args = [];
         $args[] = new Arg(new String_($serviceKey));
-        $args[] = new Arg($this->phpNodeFactory->createAbsoluteDirExpr($resource));
+        $args[] = new Arg($this->commonFactory->createAbsoluteDirExpr($resource));
 
         return new MethodCall($servicesVariable, 'load', $args);
     }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ServicesPhpNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/ServicesPhpNodeFactory.php
@@ -52,6 +52,11 @@ final class ServicesPhpNodeFactory
         $excludeMethodCall = new MethodCall($servicesLoadMethodCall, self::EXCLUDE);
 
         $excludeValue = [];
+
+        if (! is_array($exclude)) {
+            $exclude = [$exclude];
+        }
+
         foreach ($exclude as $key => $singleExclude) {
             $excludeValue[$key] = $this->phpNodeFactory->createAbsoluteDirExpr($singleExclude);
         }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/SingleServicePhpNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/SingleServicePhpNodeFactory.php
@@ -5,38 +5,28 @@ declare(strict_types=1);
 namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
 
 use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\VariableName;
-use Migrify\ConfigTransformer\Naming\ClassNaming;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
-use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Expression;
 
 final class SingleServicePhpNodeFactory
 {
     /**
-     * @var ClassNaming
+     * @var CommonFactory
      */
-    private $classNaming;
+    private $commonFactory;
 
-    public function __construct(ClassNaming $classNaming)
+    public function __construct(CommonFactory $commonFactory)
     {
-        $this->classNaming = $classNaming;
+        $this->commonFactory = $commonFactory;
     }
 
     public function createSetService(string $serviceKey): Expression
     {
-        $classReference = $this->createShortClassReference($serviceKey);
+        $classReference = $this->commonFactory->createShortClassReference($serviceKey);
         $setMethodCall = new MethodCall(new Variable(VariableName::SERVICES), 'set', [new Arg($classReference)]);
 
         return new Expression($setMethodCall);
-    }
-
-    private function createShortClassReference(string $className): ClassConstFetch
-    {
-        $shortClassName = $this->classNaming->getShortName($className);
-
-        return new ClassConstFetch(new Name($shortClassName), 'class');
     }
 }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/SingleServicePhpNodeFactory.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/NodeFactory/SingleServicePhpNodeFactory.php
@@ -4,6 +4,39 @@ declare(strict_types=1);
 
 namespace Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory;
 
+use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\VariableName;
+use Migrify\ConfigTransformer\Naming\ClassNaming;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Expression;
+
 final class SingleServicePhpNodeFactory
 {
+    /**
+     * @var ClassNaming
+     */
+    private $classNaming;
+
+    public function __construct(ClassNaming $classNaming)
+    {
+        $this->classNaming = $classNaming;
+    }
+
+    public function createSetService(string $serviceKey): Expression
+    {
+        $classReference = $this->createShortClassReference($serviceKey);
+        $setMethodCall = new MethodCall(new Variable(VariableName::SERVICES), 'set', [new Arg($classReference)]);
+
+        return new Expression($setMethodCall);
+    }
+
+    private function createShortClassReference(string $className): ClassConstFetch
+    {
+        $shortClassName = $this->classNaming->getShortName($className);
+
+        return new ClassConstFetch(new Name($shortClassName), 'class');
+    }
 }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
@@ -24,7 +24,11 @@ final class FluentMethodCallPrinter extends Standard
         $printedContent = Strings::replace($printedContent, '#^[ ]+\n#m', "\n");
 
         // remove space before " :" in main closure
-        $printedContent = Strings::replace($printedContent, '#containerConfigurator\) : void#', 'containerConfigurator): void');
+        $printedContent = Strings::replace(
+            $printedContent,
+            '#containerConfigurator\) : void#',
+            'containerConfigurator): void'
+        );
 
         return $printedContent . self::EOL_CHAR;
     }

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
@@ -23,6 +23,9 @@ final class FluentMethodCallPrinter extends Standard
         // remove trailing spaces
         $printedContent = Strings::replace($printedContent, '#^[ ]+\n#m', "\n");
 
+        // remove space before " :" in main closure
+        $printedContent = Strings::replace($printedContent, '#containerConfigurator\) : void#', 'containerConfigurator): void');
+
         return $printedContent . self::EOL_CHAR;
     }
 

--- a/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
+++ b/packages/config-transformer/packages/format-switcher/src/PhpParser/Printer/FluentMethodCallPrinter.php
@@ -33,6 +33,20 @@ final class FluentMethodCallPrinter extends Standard
         return $printedContent . self::EOL_CHAR;
     }
 
+    /**
+     * Do not preslash all slashes (parent behavior), but only those:
+     *
+     * - followed by "\"
+     * - by "'"
+     * - or the end of the string
+     *
+     * Prevents `Vendor\Class` => `Vendor\\Class`.
+     */
+    protected function pSingleQuotedString(string $string): string
+    {
+        return "'" . Strings::replace($string, "#'|\\\\(?=[\\\\']|$)#", '\\\\$0') . "'";
+    }
+
     protected function pExpr_Array(Array_ $array): string
     {
         $array->setAttribute('kind', Array_::KIND_SHORT);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php
@@ -64,7 +64,9 @@ abstract class AbstractConfigFormatConverterTest extends AbstractKernelTestCase
             return;
         }
 
-        $newOriginalContent = $inputFileInfo->getContents() . SplitLine::LINE . rtrim($convertedContent) . PHP_EOL;
+        $newOriginalContent = rtrim($inputFileInfo->getContents()) . PHP_EOL . SplitLine::LINE . rtrim(
+            $convertedContent
+        ) . PHP_EOL;
         FileSystem::write($fileInfo->getRealPath(), $newOriginalContent);
     }
 

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureXmlToPhp/some.xml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureXmlToPhp/some.xml
@@ -24,7 +24,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Component\Mime\MimeTypes;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('mime_types', MimeTypes::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
@@ -1,8 +1,7 @@
 services:
-  # default configuration for services in *this* file
-  _defaults:
-    autowire: true      # Automatically injects dependencies in your services.
-    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+    _defaults:
+        autowire: true
+        autoconfigure: false
 -----
 <?php
 
@@ -13,5 +12,5 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
 
     $services->defaults()
         ->autowire()
-        ->autoconfigure();
+        ->autoconfigure(false);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
@@ -1,0 +1,17 @@
+services:
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default.yaml
@@ -7,7 +7,7 @@ services:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
@@ -10,7 +10,7 @@ services:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
@@ -1,0 +1,19 @@
+services:
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+    bind:
+      bool $isDebug: '%kernel.debug%'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/default_with_bind.yaml
@@ -15,5 +15,6 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
 
     $services->defaults()
         ->autowire()
-        ->autoconfigure();
+        ->autoconfigure()
+        ->bind('bool $isDebug', '%kernel.debug%');
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
@@ -21,11 +21,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->instanceof(SimpleFakeClassService::class)
         ->public()
-        ->tag('app.domain_loader')
-    ;
+        ->tag('app.domain_loader');
 
     $services->instanceof(SimpleFakeClassServiceTwo::class)
         ->private()
-        ->tag('app.domain_loader')
-    ;
+        ->tag('app.domain_loader');
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
@@ -1,0 +1,31 @@
+services:
+
+  _instanceof:
+    Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+      public: true
+      tags: ['app.domain_loader']
+
+    Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo:
+      public: false
+      tags: ['app.domain_loader']
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->instanceof(SimpleFakeClassService::class)
+        ->public()
+        ->tag('app.domain_loader')
+    ;
+
+    $services->instanceof(SimpleFakeClassServiceTwo::class)
+        ->private()
+        ->tag('app.domain_loader')
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/instanceof.yaml
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->instanceof(SimpleFakeClassService::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/parameters.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/parameters.yaml
@@ -1,0 +1,42 @@
+# This file is the entry point to configure your own services.
+# Files in the packages/ subdirectory configure your dependencies.
+
+# Put parameters here that don't need to change on each machine where the app is deployed
+# https://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration
+parameters:
+  # the parameter name is an arbitrary string (the 'app.' prefix is recommended
+  # to better differentiate your parameters from Symfony parameters).
+  app.admin_email: 'something@example.com'
+
+  # boolean parameters
+  app.enable_v2_protocol: true
+
+  #global.constant.value: !php/const _MAKER_TEST_GLOBAL_CONSTANT
+  #my_class.constant.value: !php/const Symfony\Bundle\MakerBundle\Tests\Util\PhpServicesCreatorTest::CONSTANT_NAME
+
+  # array/collection parameters
+  app.supported_locales: ['en', 'es', 'fr']
+
+  # binary content parameters (encode the contents with base64_encode())
+  app.some_parameter: !!binary VGhpcyBpcyBhIEJlbGwgY2hhciAH
+
+  my_multilang.language_fallback:
+    en:
+      - en
+      - fr
+    fr:
+      - fr
+      - en
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('app.admin_email', 'something@example.com');
+    $parameters->set('app.enable_v2_protocol', true);
+    $parameters->set('app.supported_locales', ['en', 'es', 'fr']);
+    $parameters->set('app.some_parameter', 'This is a Bell char ');
+    $parameters->set('my_multilang.language_fallback', ['en' => ['en', 'fr'], 'fr' => ['fr', 'en']]);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/parameters.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/parameters.yaml
@@ -32,7 +32,7 @@ parameters:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set('app.admin_email', 'something@example.com');
     $parameters->set('app.enable_v2_protocol', true);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
@@ -4,11 +4,6 @@ services:
       - !service
         class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar
 
-  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo:
-    arguments:
-      - !service
-        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass
-
   Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree:
     factory: [ !service { class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar }, 'constructFoo' ]
 -----
@@ -17,23 +12,15 @@ services:
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar;
-use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree;
-use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassService::class)
-        ->args([inline_service(AnonymousBar::class)])
-    ;
-
-    $services->set(SimpleFakeClassServiceTwo::class)
-        ->args([inline_service(SimpleFakeClass::class)])
-    ;
+        ->args([inline_service(AnonymousBar::class)]);
 
     $services->set(SimpleFakeClassServiceThree::class)
-        ->factory([inline_service(AnonymousBar::class), 'constructFoo'])
-    ;
+        ->factory([inline_service(AnonymousBar::class), 'constructFoo']);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
@@ -1,0 +1,39 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+    arguments:
+      - !service
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo:
+    arguments:
+      - !service
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree:
+    factory: [ !service { class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar }, 'constructFoo' ]
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\AnonymousBar;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClassService::class)
+        ->args([inline_service(AnonymousBar::class)])
+    ;
+
+    $services->set(SimpleFakeClassServiceTwo::class)
+        ->args([inline_service(SimpleFakeClass::class)])
+    ;
+
+    $services->set(SimpleFakeClassServiceThree::class)
+        ->factory([inline_service(AnonymousBar::class), 'constructFoo'])
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/reference.yaml
@@ -22,7 +22,7 @@ use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\Si
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassService::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
@@ -26,7 +26,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set('app.admin_email', 'original@example.com');
 

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
@@ -36,13 +36,10 @@ return static function (ContainerConfigurator $containerConfigurator) : void {
         ->autowire()
         ->autoconfigure();
 
+    $services->set('service1', SimpleFakeClass::class)
         ->autowire(false)
-    $services->set('service1', SimpleFakeClass::class);
-    $services->set('service1', SimpleFakeClass::class)
-        ->args(['service1_arg']);
-        ->tag('service1_tag')
-    $services->set('service1', SimpleFakeClass::class)
-        ->args(['service1_arg']);
+        ->args(['service1_arg'])
+        ->tag('service1_tag');
 
     $services->set('service2', SimpleFakeClass::class)
         ->args(['service2_arg']);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services.yaml
@@ -1,0 +1,51 @@
+parameters:
+    app.admin_email: 'original@example.com'
+
+services:
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    service1:
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass
+        autowire: false
+        arguments: [service1_arg]
+        tags: [service1_tag]
+
+    service2:
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass
+        arguments: [service2_arg]
+
+    Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo $variable: '@service1'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('app.admin_email', 'original@example.com');
+
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure();
+
+        ->autowire(false)
+    $services->set('service1', SimpleFakeClass::class);
+    $services->set('service1', SimpleFakeClass::class)
+        ->args(['service1_arg']);
+        ->tag('service1_tag')
+    $services->set('service1', SimpleFakeClass::class)
+        ->args(['service1_arg']);
+
+    $services->set('service2', SimpleFakeClass::class)
+        ->args(['service2_arg']);
+
+    $services->alias(SimpleFakeClassServiceTwo::class.' $variable', 'service1');
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_alias.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_alias.yaml
@@ -16,7 +16,7 @@ use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\Si
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->alias(SimpleFakeClassService::class, 'fake.simple_class');

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_alias.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_alias.yaml
@@ -1,0 +1,30 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService: '@fake.simple_class'
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo $variable: '@App\Fake\Class'
+
+  fake.simple_class_two:
+    public: false
+    alias: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo
+    deprecated: 'The "%alias_id%" alias is deprecated. Do not use it anymore.'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->alias(SimpleFakeClassService::class, 'fake.simple_class');
+
+    $services->alias(SimpleFakeClassServiceTwo::class.' $variable', 'App\Fake\Class');
+
+    $services->alias('fake.simple_class_two', SimpleFakeClassTwo::class)
+        ->private()
+        ->deprecate('The "%alias_id%" alias is deprecated. Do not use it anymore.')
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
@@ -41,28 +41,15 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services->alias(SimpleFakeClassServiceTwo::class.' $shoutyTransformer', 'App\Util\UppercaseTransformer');
 
     $services->set(SimpleFakeClassService::class)
-        ->args([
-            service('string'),
-            ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com'],
-            456,
-            [
-                'App\FooCommand' => service('app.command_handler.foo'),
-                'App\BarCommand' => service('app.command_handler.bar'),
-            ],
-            tagged_locator('app.handler', 'key'),
-            tagged_iterator('app.handler'),
-        ])
-    ;
+        ->args(['@string', ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com'], 456, ['App\FooCommand' => '@app.command_handler.foo', 'App\BarCommand' => '@app.command_handler.bar'], 'tagged_locator(\'app.handler\', \'key\')', 'tagged_iterator(\'app.handler\')']);
 
     $services->set(SimpleFakeClassTwo::class)
-        ->args([tagged_locator('app.handler', 'key', 'myOwnMethodName')])
-    ;
+        ->args(['tagged_locator(\'app.handler\', \'key\', \'myOwnMethodName\')']);
 
     $services->set(SimpleFakeClassServiceThree::class)
-        ->arg('$fake1', service('id.fake.service'))
-        ->arg('$fake2', ['fake_argument', 123, 'jean@mail.com'])
-    ;
+        ->arg('$fake1', 'service(\'id.fake.service\')')
+        ->arg('$fake2', '[\'fake_argument\', 123, \'jean@mail.com\']');
 
     $services->set('site_update_manager.normal_users', SimpleFakeClassThree::class)
-        ->args(['@=service("App\\Mail\\MailerConfiguration").getMailerMethod()']);
+        ->args(['@=service("App\Mail\MailerConfiguration").getMailerMethod()']);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
@@ -1,0 +1,68 @@
+services:
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo $shoutyTransformer: '@App\Util\UppercaseTransformer'
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+    arguments:
+      - '@string'
+      - ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com']
+      - 456
+      -
+        App\FooCommand: '@app.command_handler.foo'
+        App\BarCommand: '@app.command_handler.bar'
+      - !tagged_locator { tag: 'app.handler', index_by: 'key' }
+      - !tagged_iterator app.handler
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo:
+    arguments: [!tagged_locator { index_by: 'key', tag: 'app.handler', default_index_method: 'myOwnMethodName' }]
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree:
+    arguments:
+      $fake1: '@id.fake.service'
+      $fake2: ['fake_argument', 123, 'jean@mail.com']
+
+  site_update_manager.normal_users:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassThree
+    arguments: ['@=service("App\Mail\MailerConfiguration").getMailerMethod()']
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceThree;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassThree;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->alias(SimpleFakeClassServiceTwo::class.' $shoutyTransformer', 'App\Util\UppercaseTransformer');
+
+    $services->set(SimpleFakeClassService::class)
+        ->args([
+            service('string'),
+            ['isaevsgdbfhhnth', 1234561456545, 'jean@vgbsetgil.com'],
+            456,
+            [
+                'App\FooCommand' => service('app.command_handler.foo'),
+                'App\BarCommand' => service('app.command_handler.bar'),
+            ],
+            tagged_locator('app.handler', 'key'),
+            tagged_iterator('app.handler'),
+        ])
+    ;
+
+    $services->set(SimpleFakeClassTwo::class)
+        ->args([tagged_locator('app.handler', 'key', 'myOwnMethodName')])
+    ;
+
+    $services->set(SimpleFakeClassServiceThree::class)
+        ->arg('$fake1', service('id.fake.service'))
+        ->arg('$fake2', ['fake_argument', 123, 'jean@mail.com'])
+    ;
+
+    $services->set('site_update_manager.normal_users', SimpleFakeClassThree::class)
+        ->args(['@=service("App\\Mail\\MailerConfiguration").getMailerMethod()']);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_arguments.yaml
@@ -35,7 +35,7 @@ use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\Si
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassThree;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->alias(SimpleFakeClassServiceTwo::class.' $shoutyTransformer', 'App\Util\UppercaseTransformer');

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
@@ -16,7 +16,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassService::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
@@ -1,0 +1,31 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+    calls:
+      - [withMailer, ['@mailer'], false]
+      - [setLogger, ['@logger']]
+      - [setMailer, ['@mailer']]
+      - { method: withMailer, arguments: ['@mailer', 'argument'], returns_clone: false }
+      - setLogger: ['@logger']
+      - setMailer: ['@mailer']
+      # and there is also a "TaggedValue" allowed ONLY if you use this last syntax
+      - withLogger: !returns_clone ['@logger']
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClassService::class)
+        ->call('withMailer', [service('mailer')], false)
+        ->call('setLogger', [service('logger')])
+        ->call('setMailer', [service('mailer')])
+        ->call('withMailer', [service('mailer'), 'argument'], false)
+        ->call('setLogger', [service('logger')])
+        ->call('setMailer', [service('mailer')])
+        ->call('withLogger', [service('logger')], true)
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_calls.yaml
@@ -26,6 +26,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->call('withMailer', [service('mailer'), 'argument'], false)
         ->call('setLogger', [service('logger')])
         ->call('setMailer', [service('mailer')])
-        ->call('withLogger', [service('logger')], true)
-    ;
+        ->call('withLogger', [service('logger')], true);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
@@ -16,13 +16,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClass::class)
-        ->configurator([
-            service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo'),
-            'configure',
-        ])
-    ;
+        ->factory([service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo'), 'configure']);
 
     $services->set(SimpleFakeClassTwo::class)
-        ->configurator(service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass'))
-    ;
+        ->factory([service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass')]);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
@@ -1,0 +1,28 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass:
+    configurator: ['@Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo', 'configure']
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo:
+    configurator: '@Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClass::class)
+        ->configurator([
+            service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo'),
+            'configure',
+        ])
+    ;
+
+    $services->set(SimpleFakeClassTwo::class)
+        ->configurator(service('Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass'))
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_configurator.yaml
@@ -12,7 +12,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClass::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
@@ -1,0 +1,48 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass:
+    decorates: App\Mailer
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo:
+    decorates: App\Mailer
+    decoration_inner_name: App\DecoratingMailer.wooz
+    decoration_priority: 5
+    decoration_on_invalid: exception
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+    decorates: App\Mailer
+    decoration_on_invalid: ignore
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClass::class)
+        ->decorate('App\Mailer')
+    ;
+
+    $services->set(SimpleFakeClassTwo::class)
+        ->decorate(
+            'App\Mailer',
+            'App\DecoratingMailer.wooz',
+            5,
+            ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE
+        )
+    ;
+
+    $services->set(SimpleFakeClassService::class)
+        ->decorate(
+            'App\Mailer',
+            null,
+            0,
+            ContainerInterface::IGNORE_ON_INVALID_REFERENCE
+        )
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
@@ -21,7 +21,7 @@ use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\Si
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClass::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_decoration.yaml
@@ -25,24 +25,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClass::class)
-        ->decorate('App\Mailer')
-    ;
+        ->decorate('App\Mailer');
 
     $services->set(SimpleFakeClassTwo::class)
-        ->decorate(
-            'App\Mailer',
-            'App\DecoratingMailer.wooz',
-            5,
-            ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE
-        )
-    ;
+        ->decorate('App\Mailer', 'App\DecoratingMailer.wooz', 5, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE);
 
     $services->set(SimpleFakeClassService::class)
-        ->decorate(
-            'App\Mailer',
-            null,
-            0,
-            ContainerInterface::IGNORE_ON_INVALID_REFERENCE
-        )
-    ;
+        ->decorate('App\Mailer', null, 0, ContainerInterface::IGNORE_ON_INVALID_REFERENCE);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_deprecation.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_deprecation.yaml
@@ -17,7 +17,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
         ->deprecate('The %service_id% service is deprecated')

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_deprecation.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_deprecation.yaml
@@ -1,0 +1,28 @@
+
+services:
+  fake.service.old_syntax:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+    deprecated: 'The %service_id% service is deprecated'
+
+  fake.service.new_syntax:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+    deprecated:
+      message: 'The %service_id% service is deprecated'
+      package: 'symfony/foobar'
+      version: '2.1'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+        ->deprecate('The %service_id% service is deprecated')
+    $services->set('fake.service.old_syntax', SimpleFakeClassService::class);
+
+        ->deprecate('symfony/foobar', '2.1', 'The %service_id% service is deprecated')
+    $services->set('fake.service.new_syntax', SimpleFakeClassService::class);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
@@ -1,16 +1,15 @@
 services:
+    string_service_factory:
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+        factory: '@factory_service_invokable'
 
-  string_service_factory:
-    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
-    factory: '@factory_service_invokable'
+    array_service_factory:
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+        factory: ['@factory_service', 'constructFoo']
 
-  array_service_factory:
-    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
-    factory: ['@factory_service', 'constructFoo']
-
-  array_static_factory:
-    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
-    factory: ['Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo', 'create']
+    array_static_factory:
+        class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+        factory: ['Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo', 'create']
 -----
 <?php
 
@@ -21,15 +20,12 @@ use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\Si
 return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
-        ->factory(service('factory_service_invokable'))
-    $services->set('string_service_factory', SimpleFakeClassService::class);
+    $services->set('string_service_factory', SimpleFakeClassService::class)
+        ->factory([service('factory_service_invokable')]);
 
-        ->factory([service('factory_service'), 'constructFoo'])
-    $services->set('array_service_factory', SimpleFakeClassService::class);
+    $services->set('array_service_factory', SimpleFakeClassService::class)
+        ->factory([service('factory_service'), 'constructFoo']);
 
-        ->factory([
-            'Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo',
-            'create',
-        ])
-    $services->set('array_static_factory', SimpleFakeClassService::class);
+    $services->set('array_static_factory', SimpleFakeClassService::class)
+        ->factory(['Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo', 'create']);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
@@ -1,0 +1,35 @@
+services:
+
+  string_service_factory:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+    factory: '@factory_service_invokable'
+
+  array_service_factory:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+    factory: ['@factory_service', 'constructFoo']
+
+  array_static_factory:
+    class: Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService
+    factory: ['Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo', 'create']
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+        ->factory(service('factory_service_invokable'))
+    $services->set('string_service_factory', SimpleFakeClassService::class);
+
+        ->factory([service('factory_service'), 'constructFoo'])
+    $services->set('array_service_factory', SimpleFakeClassService::class);
+
+        ->factory([
+            'Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassServiceTwo',
+            'create',
+        ])
+    $services->set('array_static_factory', SimpleFakeClassService::class);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_factory.yaml
@@ -18,7 +18,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
         ->factory(service('factory_service_invokable'))

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
@@ -5,6 +5,6 @@ imports:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/services_simple.yaml', __DIR__ . '/annotations', true);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
@@ -6,5 +6,5 @@ imports:
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 return static function (ContainerConfigurator $containerConfigurator): void {
-    $containerConfigurator->import(__DIR__ . '/services_simple.yaml', __DIR__ . '/annotations', true);
+    $containerConfigurator->import(__DIR__ . '/services_simple.yaml', 'annotations', true);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_imports.yaml
@@ -1,0 +1,10 @@
+imports:
+  - { 'type': 'annotations', resource: 'services_simple.yaml', ignore_errors: true }
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $containerConfigurator->import(__DIR__ . '/services_simple.yaml', __DIR__ . '/annotations', true);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
@@ -27,7 +27,7 @@ services:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->load('App\\', __DIR__ . '/../src/*')

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
@@ -1,0 +1,39 @@
+services:
+
+  # makes classes in src/ available to be used as services
+  # this creates a service per class whose id is the fully-qualified class name
+  App\:
+    resource: '../src/*'
+    exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+
+  # controllers are imported separately to make sure services can be injected
+  # as action arguments even if you don't extend any base controller class
+  App\Controller\:
+    resource: '../src/Controller'
+    tags: ['controller.service_arguments']
+    exclude: ['../src/Controller/SomeFile.php', '../src/Controller/OtherFile.php']
+
+  command_handlers:
+    namespace: App\Domain\
+    resource: '../src/Domain/*/CommandHandler'
+    tags: [command_handler]
+
+  event_subscribers:
+    namespace: App\Domain\
+    resource: '../src/Domain/*/EventSubscriber'
+    tags: [event_subscriber]
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->load('App\\', __DIR__ . '/../src/*')
+        ->exclude([__DIR__ . '/../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}']);
+    $services->load('App\\Controller\\', __DIR__ . '/../src/Controller')
+        ->exclude([__DIR__ . '/../src/Controller/SomeFile.php', __DIR__ . '/../src/Controller/OtherFile.php']);
+    $services->load('App\\Domain\\', __DIR__ . '/../src/Domain/*/CommandHandler');
+    $services->load('App\\Domain\\', __DIR__ . '/../src/Domain/*/EventSubscriber');
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_load_resources_simple.yaml
@@ -32,8 +32,11 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->load('App\\', __DIR__ . '/../src/*')
         ->exclude([__DIR__ . '/../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}']);
-    $services->load('App\\Controller\\', __DIR__ . '/../src/Controller')
+
+    $services->load('App\Controller\\', __DIR__ . '/../src/Controller')
         ->exclude([__DIR__ . '/../src/Controller/SomeFile.php', __DIR__ . '/../src/Controller/OtherFile.php']);
-    $services->load('App\\Domain\\', __DIR__ . '/../src/Domain/*/CommandHandler');
-    $services->load('App\\Domain\\', __DIR__ . '/../src/Domain/*/EventSubscriber');
+
+    $services->load('App\Domain\\', __DIR__ . '/../src/Domain/*/CommandHandler');
+
+    $services->load('App\Domain\\', __DIR__ . '/../src/Domain/*/EventSubscriber');
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_null_value.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_null_value.yaml
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassService::class);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_null_value.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_null_value.yaml
@@ -1,0 +1,14 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService: ~
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClassService::class);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_simple.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_simple.yaml
@@ -1,0 +1,14 @@
+services:
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass: ~
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClass::class);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_simple.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_simple.yaml
@@ -7,7 +7,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClass;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClass::class);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_staging.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_staging.yaml
@@ -5,7 +5,7 @@ parameters:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set('app.admin_email', 'staging@example.com');
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_staging.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_staging.yaml
@@ -1,0 +1,11 @@
+parameters:
+    app.admin_email: 'staging@example.com'
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $parameters = $containerConfigurator->parameters();
+    $parameters->set('app.admin_email', 'staging@example.com');
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
@@ -1,0 +1,29 @@
+services:
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo:
+    tags: ['app.mail_transport']
+
+  Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService:
+    tags:
+      - { name: 'app.mail_transport', alias: 'sendmail' }
+      - { name: 'app.mail_sender', alias: 'sender', priority: 512 }
+-----
+<?php
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
+use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
+
+return static function (ContainerConfigurator $containerConfigurator) : void {
+    $services = $containerConfigurator->services();
+
+    $services->set(SimpleFakeClassTwo::class)
+        ->tag('app.mail_transport')
+    ;
+
+    $services->set(SimpleFakeClassService::class)
+        ->tag('app.mail_transport', ['alias' => 'sendmail'])
+        ->tag('app.mail_sender', ['alias' => 'sender', 'priority' => 512])
+    ;
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
@@ -15,7 +15,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassService;
 use Symfony\Bundle\MakerBundle\Tests\Util\yaml_php_convert_fixtures\FakeClass\SimpleFakeClassTwo;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassTwo::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/maker-bundle/services_tags.yaml
@@ -19,11 +19,9 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SimpleFakeClassTwo::class)
-        ->tag('app.mail_transport')
-    ;
+        ->tag('app.mail_transport');
 
     $services->set(SimpleFakeClassService::class)
         ->tag('app.mail_transport', ['alias' => 'sendmail'])
-        ->tag('app.mail_sender', ['alias' => 'sender', 'priority' => 512])
-    ;
+        ->tag('app.mail_sender', ['alias' => 'sender', 'priority' => 512]);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/autodiscovery.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/autodiscovery.yaml
@@ -10,7 +10,7 @@ services:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/autodiscovery.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/autodiscovery.yaml
@@ -17,5 +17,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire()
         ->public();
 
-    $services->load('Symplify\\Autodiscovery\\', __DIR__ . '/../src');
+    $services->load('Symplify\Autodiscovery\\', __DIR__ . '/../src');
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/defaults.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/defaults.yaml
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symplify\SmartFileSystem\Finder\FinderSanitizer;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/exclude.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/exclude.yaml
@@ -20,6 +20,6 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autowire()
         ->public();
 
-    $services->load('Symplify\\Autodiscovery\\', __DIR__ . '/../src')
+    $services->load('Symplify\Autodiscovery\\', __DIR__ . '/../src')
         ->exclude([__DIR__ . '/../src/HttpKernel/*', __DIR__ . '/../src/That/*']);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/exclude.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/exclude.yaml
@@ -13,7 +13,7 @@ services:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->defaults()

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/imports.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/imports.yaml
@@ -6,7 +6,7 @@ imports:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $containerConfigurator->import(__DIR__ . '/import_me.yml');
     $containerConfigurator->import(__DIR__ . '/import_me.yml', true);
 };

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/parameters.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/nested/some_config/parameters.yaml
@@ -7,7 +7,7 @@ parameters:
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $parameters = $containerConfigurator->parameters();
     $parameters->set('package_directories', ['packages']);
     $parameters->set('package_directories_excludes', []);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/alias.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/alias.yaml
@@ -9,7 +9,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->alias(EventDispatcherInterface::class, EventDispatcher::class);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/simple_arguments.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/simple_arguments.yaml
@@ -9,7 +9,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use GuzzleHttp\Client;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('gateway.api.client', Client::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/some.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/FixtureYamlToPhp/normal/some.yaml
@@ -13,7 +13,7 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use GuzzleHttp\Client;
 
-return static function (ContainerConfigurator $containerConfigurator) : void {
+return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('gateway.api.client', Client::class)

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhpTest.php
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhpTest.php
@@ -28,6 +28,22 @@ final class YamlToPhpTest extends AbstractConfigFormatConverterTest
         $this->doTestOutputWithExtraDirectory($fileInfo, __DIR__ . '/FixtureYamlToPhp/nested', 'yaml', 'php');
     }
 
+    /**
+     * @source https://github.com/symfony/maker-bundle/pull/604
+     * @dataProvider provideDataMakerBundle()
+     */
+    public function testMakerBundle(SmartFileInfo $fileInfo): void
+    {
+        // needed for all the included
+        $temporaryPath = StaticFixtureSplitter::getTemporaryPath();
+        FileSystem::write($temporaryPath . '/../src/SomeClass.php', '<?php namespace App { class SomeClass {} }');
+        require_once $temporaryPath . '/../src/SomeClass.php';
+        FileSystem::createDir($temporaryPath . '/../src/Controller');
+        FileSystem::createDir($temporaryPath . '/../src/Domain');
+
+        $this->doTestOutput($fileInfo, 'yaml', 'php');
+    }
+
     public function provideData(): Iterator
     {
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/FixtureYamlToPhp/normal', '*.yaml');
@@ -36,6 +52,11 @@ final class YamlToPhpTest extends AbstractConfigFormatConverterTest
     public function provideDataWithDirectory(): Iterator
     {
         return StaticFixtureFinder::yieldDirectory(__DIR__ . '/FixtureYamlToPhp/nested', '*.yaml');
+    }
+
+    public function provideDataMakerBundle(): Iterator
+    {
+        return StaticFixtureFinder::yieldDirectory(__DIR__ . '/FixtureYamlToPhp/maker-bundle', '*.yaml');
     }
 
     private function doTestOutputWithExtraDirectory(


### PR DESCRIPTION
Ref #39

Mimics tests from https://github.com/symfony/maker-bundle/pull/604

<br>

@weaverryan @archeoprog 
I'm trying to mimic your original tests, to go for full feature coverage

I hope this will make features comply to your standards and easier to re-use parts in maker-bundle.


- `bind` covered :heavy_check_mark: 
- `__DIR__` only on path in import, not type
- !tagged support moving to php-parser
- @reference support moving to php-parser

<br>

:warning:  **It is still crappy, because it support both stringy-printing and strict php-parser nodes**. There must remain bridge between them for time being, to make tests somewhat pass. There are still many false positives. Once string-printing is removed, lot of code can be removed and stabilized.