### PR TITLE
[vendor-patch] Attempt to clarify "this package needs to be in root to work"

### DIFF
--- a/packages/vendor-patches/README.md
+++ b/packages/vendor-patches/README.md
@@ -7,11 +7,9 @@ Generate vendor patches for packages with single command.
 ## Install
 
 ```bash
+# this package needs to be in root to work
 composer require cweagans/composer-patches --dev
 composer require migrify/vendor-patches --dev
-
-# this package needs to be in root to work 
-cp -R vendor/migrify/vendor-patches/bin ./
 ```
 
 ## Usage
@@ -43,7 +41,7 @@ Only `*.php` file is loaded, not the `*.php.old` one. This way you can **be sure
 ### 3. Run `generate` command ~~for every single file changed this way~~ once for all files 🎆
 
 ```bash
-bin/vendor-patches generate
+vendor/bin/vendor-patches generate
 ```
 
 This tool will generate patch files for all files created this way in `/patches` directory:

--- a/packages/vendor-patches/README.md
+++ b/packages/vendor-patches/README.md
@@ -7,9 +7,11 @@ Generate vendor patches for packages with single command.
 ## Install
 
 ```bash
-# this package needs to be in root to work 
 composer require cweagans/composer-patches --dev
 composer require migrify/vendor-patches --dev
+
+# this package needs to be in root to work 
+cp -R vendor/migrify/vendor-patches/bin ./
 ```
 
 ## Usage
@@ -41,7 +43,7 @@ Only `*.php` file is loaded, not the `*.php.old` one. This way you can **be sure
 ### 3. Run `generate` command ~~for every single file changed this way~~ once for all files 🎆
 
 ```bash
-vendor/bin/vendor-patches generate
+bin/vendor-patches generate
 ```
 
 This tool will generate patch files for all files created this way in `/patches` directory:

--- a/packages/vendor-patches/bin/vendor-patches
+++ b/packages/vendor-patches/bin/vendor-patches
@@ -5,6 +5,7 @@ use Migrify\VendorPatches\Console\VendorPatchesApplication;
 use Migrify\VendorPatches\HttpKernel\VendorPatchesKernel;
 
 $possibleAutoloadPaths = [
+    __DIR__ . '/../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
     __DIR__ . '/../../../vendor/autoload.php',
 ];

--- a/packages/vendor-patches/composer.json
+++ b/packages/vendor-patches/composer.json
@@ -23,5 +23,6 @@
         "psr-4": {
             "Migrify\\VendorPatches\\Tests\\": "tests"
         }
-    }
+    },
+    "bin": ["bin/vendor-patches"]
 }


### PR DESCRIPTION
An attempt to clarify `# this package needs to be in root to work` by copying package's `bin` directory to the project root and updated the generate command to reflect being run from the project root

I'm not sure this is the best way to convey the requirement (or if it even meets the requirement) as it is simply what I figured out after backtracking through some of the code making my first patch, It may be worth considering updating the $possibleAutoloadsPaths array instead allowing it to be run from the `/vendors/migrify/vendor-patch/bin` folder but I'm not sure if there are any constraints that would make that non-practical.