### PR TITLE
Add additional vendor-patches autoload path for Composer installs

### DIFF
--- a/packages/vendor-patches/bin/85-vendor-patches-autoload-fix
+++ b/packages/vendor-patches/bin/85-vendor-patches-autoload-fix
@@ -7,6 +7,7 @@ use Migrify\VendorPatches\HttpKernel\VendorPatchesKernel;
 $possibleAutoloadPaths = [
     __DIR__ . '/../autoload.php',
     __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
     __DIR__ . '/../../../vendor/autoload.php',
 ];
 


### PR DESCRIPTION
Refer to #85. When you `composer require migrify/vendor-patches`, and run `vendor/bin/vendor-patches`, that is symlinked to `vendor/migrify/vendor-patches/bin/vendor-patches`, so `autoload.php` will be three levels up.