### PR TITLE
Fix typo in docs

### DIFF
--- a/packages/config-transformer/README.md
+++ b/packages/config-transformer/README.md
@@ -17,13 +17,13 @@ What features do we have here?
 ## 1. Convert Config Formats From XML/YAML to PHP/YAMl
 
 ```bash
-vendor/bin/config-transformer switch-format app/config --intput-format xml --output-format yaml
+vendor/bin/config-transformer switch-format app/config --input-format xml --output-format yaml
 ```
 
 You can also add `target-symfony-version` to specify, what Symfony features should be used.
 
 ```bash
-vendor/bin/config-transformer switch-format app/config --intput-format xml --output-format yaml --target-symfony-version 3.3
+vendor/bin/config-transformer switch-format app/config --input-format xml --output-format yaml --target-symfony-version 3.3
 ```
 
 <br>


### PR DESCRIPTION
The "--intput-format" option does not exist.