### PR TITLE
[ConfigTransformer] Add extension support

### DIFF
--- a/packages/config-transformer/packages/feature-shifter/src/ValueObject/YamlKey.php
+++ b/packages/config-transformer/packages/feature-shifter/src/ValueObject/YamlKey.php
@@ -90,4 +90,12 @@ final class YamlKey
      * @var string
      */
     public const CLASS_KEY = 'class';
+
+    /**
+     * @return string[]
+     */
+    public function provideRootKeys(): array
+    {
+        return [self::PARAMETERS, self::IMPORTS, self::SERVICES];
+    }
 }

--- a/packages/config-transformer/packages/format-switcher/config/config.php
+++ b/packages/config-transformer/packages/format-switcher/config/config.php
@@ -17,7 +17,12 @@ return static function (ContainerConfigurator $containerConfigurator): void {
         ->autoconfigure();
 
     $services->load('Migrify\ConfigTransformer\FormatSwitcher\\', __DIR__ . '/../src')
-        ->exclude([__DIR__ . '/../src/DependencyInjection/Loader/*', __DIR__ . '/../src/ValueObject/*']);
+        ->exclude([
+            __DIR__ . '/../src/DependencyInjection/Loader/*',
+            __DIR__ . '/../src/ValueObject/*',
+            // configurable class for faking extensions
+            __DIR__ . '/../src/DependencyInjection/Extension/AliasConfigurableExtension.php',
+        ]);
 
     $services->set(BuilderFactory::class);
 

--- a/packages/config-transformer/packages/format-switcher/src/CaseConverter/ExtensionConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/CaseConverter/ExtensionConverter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\CaseConverter;
+
+use Migrify\ConfigTransformer\FeatureShifter\ValueObject\YamlKey;
+use Migrify\ConfigTransformer\FormatSwitcher\Contract\CaseConverterInterface;
+use Migrify\ConfigTransformer\FormatSwitcher\PhpParser\NodeFactory\ArgsNodeFactory;
+use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\MethodName;
+use Migrify\ConfigTransformer\FormatSwitcher\ValueObject\VariableName;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+
+/**
+ * Handles this part:
+ *
+ * framework: <---
+ *     key: value
+ */
+final class ExtensionConverter implements CaseConverterInterface
+{
+    /**
+     * @var ArgsNodeFactory
+     */
+    private $argsNodeFactory;
+
+    /**
+     * @var string
+     */
+    private $rootKey;
+
+    /**
+     * @var YamlKey
+     */
+    private $yamlKey;
+
+    public function __construct(ArgsNodeFactory $argsNodeFactory, YamlKey $yamlKey)
+    {
+        $this->argsNodeFactory = $argsNodeFactory;
+        $this->yamlKey = $yamlKey;
+    }
+
+    public function convertToMethodCall($key, $values): Expression
+    {
+        $args = $this->argsNodeFactory->createFromValues([
+            $this->rootKey,
+            [$key => $values],
+        ]);
+
+        $containerConfiguratorVariable = new Variable(VariableName::CONTAINER_CONFIGURATOR);
+        $methodCall = new MethodCall($containerConfiguratorVariable, MethodName::EXTENSION, $args);
+
+        return new Expression($methodCall);
+    }
+
+    public function match(string $rootKey, $key, $values): bool
+    {
+        $this->rootKey = $rootKey;
+
+        return ! in_array($rootKey, $this->yamlKey->provideRootKeys(), true);
+    }
+}

--- a/packages/config-transformer/packages/format-switcher/src/DependencyInjection/Extension/AliasConfigurableExtension.php
+++ b/packages/config-transformer/packages/format-switcher/src/DependencyInjection/Extension/AliasConfigurableExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\DependencyInjection\Extension;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
+
+final class AliasConfigurableExtension extends Extension
+{
+    /**
+     * @var string
+     */
+    private $alias;
+
+    public function __construct(string $alias)
+    {
+        $this->alias = $alias;
+    }
+
+    public function getAlias(): string
+    {
+        return $this->alias;
+    }
+
+    public function load(array $configs, ContainerBuilder $containerBuilder): void
+    {
+    }
+}

--- a/packages/config-transformer/packages/format-switcher/src/DependencyInjection/ExtensionFaker.php
+++ b/packages/config-transformer/packages/format-switcher/src/DependencyInjection/ExtensionFaker.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrify\ConfigTransformer\FormatSwitcher\DependencyInjection;
+
+use Migrify\ConfigTransformer\FeatureShifter\ValueObject\YamlKey;
+use Migrify\ConfigTransformer\FormatSwitcher\DependencyInjection\Extension\AliasConfigurableExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+
+final class ExtensionFaker
+{
+    /**
+     * @var YamlKey
+     */
+    private $yamlKey;
+
+    public function __construct(YamlKey $yamlKey)
+    {
+        $this->yamlKey = $yamlKey;
+    }
+
+    public function fakeInContainerBuilder(ContainerBuilder $containerBuilder, string $yamlContent): void
+    {
+        $yaml = Yaml::parse($yamlContent, Yaml::PARSE_CUSTOM_TAGS);
+        $rootKeys = array_keys($yaml);
+
+        /** @var string[] $extensionKeys */
+        $extensionKeys = array_diff($rootKeys, $this->yamlKey->provideRootKeys());
+        if ($extensionKeys === []) {
+            return;
+        }
+
+        foreach ($extensionKeys as $extensionKey) {
+            $aliasConfigurableExtension = new AliasConfigurableExtension($extensionKey);
+            $containerBuilder->registerExtension($aliasConfigurableExtension);
+        }
+    }
+}

--- a/packages/config-transformer/packages/format-switcher/src/ValueObject/MethodName.php
+++ b/packages/config-transformer/packages/format-switcher/src/ValueObject/MethodName.php
@@ -35,4 +35,9 @@ final class MethodName
      * @var string
      */
     public const INSTANCEOF = 'instanceof';
+
+    /**
+     * @var string
+     */
+    public const EXTENSION = 'extension';
 }

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/framework_extension.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/normal/framework_extension.yaml
@@ -1,0 +1,12 @@
+framework:
+    key: value
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $containerConfigurator->extension('framework', ['key' => 'value']);
+};


### PR DESCRIPTION
Closes #119 

Firt application converted: https://github.com/TomasVotruba/tomasvotruba.com/pull/1028

---

## Design Choices

By default, converter now uses one call per per logic call, e.g.

```php
$parameters->set(...);

$parameters->set(...);

$services->set(...);

$services->set(...);
```

This architecture separates unrelated items and gives one way to develop this tool.

<br>

Saying that, the grouped extension parameters as we now them from YAML, would normally great one big groupped messy item trian:

```php
$parameters->set(...
   ->set(...)
   ->set(...)
```

That get's even worse when you try to configure extension like Doctrine with dbal, orm, configuration etc.


Current output now separates configuration per key, makes it bit unusually to YAML, but consistent with other converted cases:

![image](https://user-images.githubusercontent.com/924196/88474110-ee7a0300-cf23-11ea-847a-e239b6d1365d.png)


In the end, I like how first reaction was WTF, then "oh, it makes code cleaner" :wink: 

<br>

*Note: configs are merged, so no need to worry about last-item-winner bug*