### PR TITLE
[ConfigTransformer] Add support for all args for route import in YAML

### DIFF
--- a/packages/config-transformer/packages/format-switcher/src/RoutingCaseConverter/ImportRoutingCaseConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/RoutingCaseConverter/ImportRoutingCaseConverter.php
@@ -11,13 +11,50 @@ use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
+use Symplify\PackageBuilder\Strings\StringFormatConverter;
 
 final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
 {
     /**
      * @var string[]
      */
-    private const NESTED_KEYS = ['prefix'];
+    private const NESTED_KEYS = [
+        'name_prefix',
+        'defaults',
+        'requirements',
+        'options',
+        'utf8',
+        'condition',
+        'host',
+        'schemes',
+        self::METHODS,
+        'controller',
+        'locale',
+        'format',
+        'stateless',
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const IMPORT_ARGS = [
+        self::RESOURCE,
+        self::TYPE,
+        self::EXCLUDE,
+    ];
+
+    /**
+     * @var string[]
+     */
+    private const PREFIX_ARGS = [
+        self::PREFIX, // Add prefix itself as first argument
+        'trailing_slash_on_root',
+    ];
+
+    /**
+     * @var string
+     */
+    private const PREFIX = 'prefix';
 
     /**
      * @var string
@@ -25,13 +62,34 @@ final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
     private const RESOURCE = 'resource';
 
     /**
+     * @var string
+     */
+    private const TYPE = 'type';
+
+    /**
+     * @var string
+     */
+    private const EXCLUDE = 'exclude';
+
+    /**
+     * @var string
+     */
+    private const METHODS = 'methods';
+
+    /**
      * @var ArgsNodeFactory
      */
     private $argsNodeFactory;
 
+    /**
+     * @var StringFormatConverter
+     */
+    private $stringFormatConverter;
+
     public function __construct(ArgsNodeFactory $argsNodeFactory)
     {
         $this->argsNodeFactory = $argsNodeFactory;
+        $this->stringFormatConverter = new StringFormatConverter();
     }
 
     public function match(string $key, $values): bool
@@ -43,33 +101,54 @@ final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
     {
         $variable = new Variable(VariableName::ROUTING_CONFIGURATOR);
 
-        // @todo args
-
-        $args = $this->createAddArgs($values);
+        $args = $this->createAddArgs(self::IMPORT_ARGS, $values);
         $methodCall = new MethodCall($variable, 'import', $args);
+
+        // Handle prefix independently as it has specific args
+        if (isset($values[self::PREFIX])) {
+            $args = $this->createAddArgs(self::PREFIX_ARGS, $values);
+            $methodCall = new MethodCall($methodCall, self::PREFIX, $args);
+        }
 
         foreach (self::NESTED_KEYS as $nestedKey) {
             if (! isset($values[$nestedKey])) {
                 continue;
             }
 
-            $args = $this->argsNodeFactory->createFromValues([$values[$nestedKey]]);
-            $methodCall = new MethodCall($methodCall, $nestedKey, $args);
+            $nestedValues = $values[$nestedKey];
+
+            // Transform methods as string GET|HEAD to array
+            if ($nestedKey === self::METHODS && \is_string($nestedValues)) {
+                $nestedValues = \explode('|', $nestedValues);
+            }
+
+            $args = $this->argsNodeFactory->createFromValues([$nestedValues]);
+            $name = $this->stringFormatConverter->underscoreAndHyphenToCamelCase($nestedKey);
+
+            $methodCall = new MethodCall($methodCall, $name, $args);
         }
 
         return new Expression($methodCall);
     }
 
     /**
+     * @param string[] $argsNames
      * @param mixed $values
      * @return Arg[]
      */
-    private function createAddArgs($values): array
+    private function createAddArgs(array $argsNames, $values): array
     {
         $argumentValues = [];
 
-        if (isset($values[self::RESOURCE])) {
-            $argumentValues[] = $values[self::RESOURCE];
+        foreach ($argsNames as $arg) {
+            if (isset($values[$arg])) {
+                // Default $ignoreErrors to false before $exclude on import(), same behaviour as symfony
+                if ($arg === self::EXCLUDE) {
+                    $argumentValues[] = false;
+                }
+
+                $argumentValues[] = $values[$arg];
+            }
         }
 
         return $this->argsNodeFactory->createFromValues($argumentValues);

--- a/packages/config-transformer/packages/format-switcher/src/RoutingCaseConverter/ImportRoutingCaseConverter.php
+++ b/packages/config-transformer/packages/format-switcher/src/RoutingCaseConverter/ImportRoutingCaseConverter.php
@@ -12,6 +12,8 @@ use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Stmt\Expression;
 use Symplify\PackageBuilder\Strings\StringFormatConverter;
+use function explode;
+use function is_string;
 
 final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
 {
@@ -37,17 +39,14 @@ final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
     /**
      * @var string[]
      */
-    private const IMPORT_ARGS = [
-        self::RESOURCE,
-        self::TYPE,
-        self::EXCLUDE,
-    ];
+    private const IMPORT_ARGS = [self::RESOURCE, self::TYPE, self::EXCLUDE];
 
     /**
      * @var string[]
      */
     private const PREFIX_ARGS = [
-        self::PREFIX, // Add prefix itself as first argument
+        // Add prefix itself as first argument
+        self::PREFIX,
         'trailing_slash_on_root',
     ];
 
@@ -118,8 +117,8 @@ final class ImportRoutingCaseConverter implements RoutingCaseConverterInterface
             $nestedValues = $values[$nestedKey];
 
             // Transform methods as string GET|HEAD to array
-            if ($nestedKey === self::METHODS && \is_string($nestedValues)) {
-                $nestedValues = \explode('|', $nestedValues);
+            if ($nestedKey === self::METHODS && is_string($nestedValues)) {
+                $nestedValues = explode('|', $nestedValues);
             }
 
             $args = $this->argsNodeFactory->createFromValues([$nestedValues]);

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/full_import.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/full_import.yaml
@@ -1,0 +1,46 @@
+api_platform:
+    resource: .
+    type: api_platform
+    exclude: '../../src/Controller/{DebugEmailController}.php'
+    prefix: /api
+    trailing_slash_on_root: false
+    name_prefix: api_
+    defaults:
+        _locale: 'en'
+    requirements:
+        _locale: 'en|es|fr'
+    options:
+        my_option: 'my_value'
+    utf8: false
+    condition: 'context.getMethod() in ["GET", "HEAD"] and request.headers.get("User-Agent") matches "/firefox/i"'
+    host: 'https://github.com/migrify/config-transformer'
+    schemes: ['https']
+    methods: 'GET|HEAD'
+    controller: 'App\Controller\BlogApiController::show'
+    locale: 'en'
+    format: 'html'
+    stateless: false
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routingConfigurator): void {
+    $routingConfigurator->import('.', 'api_platform', false, '../../src/Controller/{DebugEmailController}.php')
+        ->prefix('/api', false)
+        ->namePrefix('api_')
+        ->defaults(['_locale' => 'en'])
+        ->requirements(['_locale' => 'en|es|fr'])
+        ->options(['my_option' => 'my_value'])
+        ->utf8(false)
+        ->condition('context.getMethod() in ["GET", "HEAD"] and request.headers.get("User-Agent") matches "/firefox/i"')
+        ->host('https://github.com/migrify/config-transformer')
+        ->schemes(['https'])
+        ->methods(['GET', 'HEAD'])
+        ->controller('App\Controller\BlogApiController::show')
+        ->locale('en')
+        ->format('html')
+        ->stateless(false);
+};

--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/simple_import.yaml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/YamlToPhp/Fixture/routing/simple_import.yaml
@@ -1,0 +1,15 @@
+api_platform:
+    resource: .
+    type: api_platform
+    prefix: /api
+-----
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Routing\Loader\Configurator\RoutingConfigurator;
+
+return static function (RoutingConfigurator $routingConfigurator): void {
+    $routingConfigurator->import('.', 'api_platform')
+        ->prefix('/api');
+};


### PR DESCRIPTION
PR for #132.

While updating to support `type` it felt wrong not to implement all the arguments. 
So here it is! :smile: