### PR TITLE
Fix warning with empty argument

### DIFF
--- a/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/some.xml
+++ b/packages/config-transformer/packages/format-switcher/tests/Converter/ConfigFormatConverter/XmlToPhp/Fixture/some.xml
@@ -8,6 +8,7 @@
         <defaults public="false" />
 
         <service id="mime_types" class="Migrify\ConfigTransformer\FormatSwitcher\Tests\Converter\ConfigFormatConverter\Source\MimeTypes">
+            <argument />
             <call method="setDefault">
                 <argument type="service" id="mime_types" />
             </call>
@@ -30,6 +31,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set('mime_types', MimeTypes::class)
+        ->args([''])
         ->call('setDefault', [ref('mime_types')])
         ->call('setExtra', ['10000']);
 };

--- a/packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
+++ b/packages/php-config-printer/src/NodeFactory/ArgsNodeFactory.php
@@ -205,6 +205,10 @@ final class ArgsNodeFactory
         bool $skipServiceReference,
         bool $skipClassesToConstantReference
     ): Expr {
+        if ($value === '') {
+            return new String_($value);
+        }
+
         $constFetch = $this->constantNodeFactory->createConstantIfValue($value);
         if ($constFetch !== null) {
             return $constFetch;


### PR DESCRIPTION
Hi, I'm not sure if this is the proper place and the proper fix 😬 , but when you are trying to convert an xml configuration to php like:
```xml
<service id="my_id" class="App\Class">
    <argument type="service" id="router"/>
    <argument/>
</service>
```
You get:
```
PHP Notice:  Uninitialized string offset: 0 in /my/path/vendor/migrify/php-config-printer/src/NodeFactory/ArgsNodeFactory.php on line 223
```