### PR TITLE
[Downgrade PHP 7.1] Fixed different signatures for function `match`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,10 @@
         "symfony/finder": "^4.4|^5.1",
         "symfony/http-kernel": "^4.4|^5.1",
         "symfony/yaml": "^4.4|^5.1",
-        "symplify/autowire-array-parameter": "^8.3.33",
-        "symplify/composer-json-manipulator": "^8.3.33",
-        "symplify/package-builder": "^8.3.33",
-        "symplify/smart-file-system": "^8.3.33"
+        "symplify/autowire-array-parameter": "^8.3.35",
+        "symplify/composer-json-manipulator": "^8.3.35",
+        "symplify/package-builder": "^8.3.35",
+        "symplify/smart-file-system": "^8.3.35"
     },
     "require-dev": {
         "composer/composer": "^1.10",
@@ -48,11 +48,11 @@
         "symfony/routing": "^4.4|^5.1",
         "symfony/security-bundle": "^4.4|^5.1",
         "symfony/security-core": "^4.4|^5.1",
-        "symplify/changelog-linker": "^8.3.33",
-        "symplify/easy-coding-standard": "^8.3.33",
-        "symplify/easy-testing": "^8.3.33",
-        "symplify/monorepo-builder": "^8.3.33",
-        "symplify/phpstan-extensions": "^8.3.33",
+        "symplify/changelog-linker": "^8.3.35",
+        "symplify/easy-coding-standard": "^8.3.35",
+        "symplify/easy-testing": "^8.3.35",
+        "symplify/monorepo-builder": "^8.3.35",
+        "symplify/phpstan-extensions": "^8.3.35",
         "tracy/tracy": "^2.7"
     },
     "autoload": {

--- a/packages/config-feature-bumper/composer.json
+++ b/packages/config-feature-bumper/composer.json
@@ -16,7 +16,7 @@
         "migrify/migrify-kernel": "^0.4"
     },
     "require-dev": {
-        "symplify/easy-testing": "^8.3.33",
+        "symplify/easy-testing": "^8.3.35",
         "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {

--- a/packages/config-pretifier/composer.json
+++ b/packages/config-pretifier/composer.json
@@ -16,7 +16,7 @@
         "migrify/migrify-kernel": "^0.4"
     },
     "require-dev": {
-        "symplify/easy-testing": "^8.3.33",
+        "symplify/easy-testing": "^8.3.35",
         "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {

--- a/packages/config-transformer/composer.json
+++ b/packages/config-transformer/composer.json
@@ -19,7 +19,7 @@
         "migrify/migrify-kernel": "^0.4"
     },
     "require-dev": {
-        "symplify/easy-testing": "^8.3.33",
+        "symplify/easy-testing": "^8.3.35",
         "phpunit/phpunit": "^8.5|^9.0",
         "symfony/framework-bundle": "^4.4|^5.1"
     },

--- a/packages/migrify-kernel/composer.json
+++ b/packages/migrify-kernel/composer.json
@@ -7,9 +7,9 @@
         "symfony/console": "^4.4|^5.1",
         "symfony/dependency-injection": "^4.4|^5.1",
         "symfony/http-kernel": "^4.4|^5.1",
-        "symplify/package-builder": "^8.3.33",
-        "symplify/smart-file-system": "^8.3.33",
-        "symplify/autowire-array-parameter": "^8.3.33"
+        "symplify/package-builder": "^8.3.35",
+        "symplify/smart-file-system": "^8.3.35",
+        "symplify/autowire-array-parameter": "^8.3.35"
     },
     "require-dev": {
         "tracy/tracy": "^2.7"

--- a/packages/php-config-printer/composer.json
+++ b/packages/php-config-printer/composer.json
@@ -10,7 +10,7 @@
         "migrify/migrify-kernel": "^0.4"
     },
     "require-dev": {
-        "symplify/easy-testing": "^8.3.33",
+        "symplify/easy-testing": "^8.3.35",
         "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {

--- a/packages/php-config-printer/src/Contract/NestedCaseConverterInterface.php
+++ b/packages/php-config-printer/src/Contract/NestedCaseConverterInterface.php
@@ -8,7 +8,7 @@ use PhpParser\Node\Stmt\Expression;
 
 interface NestedCaseConverterInterface
 {
-    public function match(string $rootKey, string $subKey): bool;
+    public function match(string $rootKey, $subKey): bool;
 
     public function convertToMethodCall($key, $values): Expression;
 }

--- a/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Fixture/expected_value_object_file.php.inc
+++ b/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Fixture/expected_value_object_file.php.inc
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\SecondClass;
-use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\SimpleValueObject;
+use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\Simple;
 use function Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\custom_inline_object_function;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SecondClass::class)
-        ->call('configure', [['some_key' => custom_inline_object_function(new SimpleValueObject('Steve'))]]);
+        ->call('configure', [['some_key' => custom_inline_object_function(new Simple('Steve'))]]);
 };

--- a/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Fixture/expected_value_objects_file.php.inc
+++ b/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Fixture/expected_value_objects_file.php.inc
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\SecondClass;
-use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\SimpleValueObject;
+use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\Simple;
 use function Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\custom_inline_objects_function;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 
@@ -11,5 +11,5 @@ return static function (ContainerConfigurator $containerConfigurator): void {
     $services = $containerConfigurator->services();
 
     $services->set(SecondClass::class)
-        ->call('configure', [['some_key' => custom_inline_objects_function([new SimpleValueObject('Paul')])]]);
+        ->call('configure', [['some_key' => custom_inline_objects_function([new Simple('Paul')])]]);
 };

--- a/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/SmartPhpConfigPrinterTest.php
+++ b/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/SmartPhpConfigPrinterTest.php
@@ -10,7 +10,7 @@ use Migrify\PhpConfigPrinter\Printer\SmartPhpConfigPrinter;
 use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ClassWithConstants;
 use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\FirstClass;
 use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\SecondClass;
-use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\SimpleValueObject;
+use Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject\Simple;
 use Migrify\PhpConfigPrinter\ValueObject\Option;
 use Symplify\PackageBuilder\Parameter\ParameterProvider;
 use Symplify\PackageBuilder\Tests\AbstractKernelTestCase;
@@ -68,13 +68,13 @@ final class SmartPhpConfigPrinterTest extends AbstractKernelTestCase
 
         yield [[
             SecondClass::class => [
-                'some_key' => new SimpleValueObject('Steve'),
+                'some_key' => new Simple('Steve'),
             ],
         ], __DIR__ . '/Fixture/expected_value_object_file.php.inc'];
 
         yield [[
             SecondClass::class => [
-                'some_key' => [new SimpleValueObject('Paul')],
+                'some_key' => [new Simple('Paul')],
             ],
         ], __DIR__ . '/Fixture/expected_value_objects_file.php.inc'];
     }

--- a/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Source/ValueObject/Simple.php
+++ b/packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Source/ValueObject/Simple.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Migrify\PhpConfigPrinter\Tests\Printer\SmartPhpConfigPrinter\Source\ValueObject;
 
-final class SimpleValueObject
+final class Simple
 {
     /**
      * @var string

--- a/packages/phpmd-decomposer/composer.json
+++ b/packages/phpmd-decomposer/composer.json
@@ -7,12 +7,12 @@
         "nette/utils": "^3.1",
         "nette/neon": "^3.0",
         "symfony/http-kernel": "^4.4|^5.1",
-        "symplify/package-builder": "^8.3.33",
+        "symplify/package-builder": "^8.3.35",
         "migrify/php-config-printer": "^0.4",
         "migrify/migrify-kernel": "^0.4"
     },
     "require-dev": {
-        "symplify/easy-testing": "^8.3.33",
+        "symplify/easy-testing": "^8.3.35",
         "phpunit/phpunit": "^8.5|^9.0"
     },
     "autoload": {

--- a/packages/psr4-switcher/composer.json
+++ b/packages/psr4-switcher/composer.json
@@ -12,9 +12,9 @@
         "symfony/dependency-injection": "^4.4|^5.1",
         "symfony/console": "^4.4|^5.1",
         "symfony/http-kernel": "^4.4|^5.1",
-        "symplify/composer-json-manipulator": "^8.3.33",
-        "symplify/package-builder": "^8.3.33",
-        "symplify/smart-file-system": "^8.3.33"
+        "symplify/composer-json-manipulator": "^8.3.35",
+        "symplify/package-builder": "^8.3.35",
+        "symplify/smart-file-system": "^8.3.35"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.0"

--- a/packages/symfony-route-usage/composer.json
+++ b/packages/symfony-route-usage/composer.json
@@ -6,8 +6,8 @@
     "require": {
         "php": ">=7.2",
         "ext-pdo": "*",
-        "symplify/package-builder": "^8.3.33",
-        "symplify/smart-file-system": "^8.3.33",
+        "symplify/package-builder": "^8.3.35",
+        "symplify/smart-file-system": "^8.3.35",
         "knplabs/doctrine-behaviors": "^2.0.7"
     },
     "require-dev": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -74,6 +74,18 @@ parameters:
                  # suffixes
                 - packages/config-transformer/src/Configuration/Configuration.php
                 - packages/config-feature-bumper/src/Yaml/YamlServiceProcessor.php
+        
+        -
+            message: '#Property with protected modifier is not allowed\. Use interface instead#'
+            paths:
+                - packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php # 26
+                - packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php # 31
+                - packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php # 36
+
+        -
+            message: '#Value Object class name "SimpleValueObject" must be withotu "ValueObject" suffix\. The correct class name is "Simple"#'
+            paths:
+                - packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Source/ValueObject/SimpleValueObject.php
 
         - '#Class with base "FileFinder" name is already used in "PHPStan\\File\\FileFinder", "Migrify\\ClassPresence\\Finder\\FileFinder"\. Use unique name to make classes easy to recognize#'
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -82,11 +82,6 @@ parameters:
                 - packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php # 31
                 - packages/config-transformer/tests/Converter/ConfigFormatConverter/AbstractConfigFormatConverterTest.php # 36
 
-        -
-            message: '#Value Object class name "SimpleValueObject" must be withotu "ValueObject" suffix\. The correct class name is "Simple"#'
-            paths:
-                - packages/php-config-printer/tests/Printer/SmartPhpConfigPrinter/Source/ValueObject/SimpleValueObject.php
-
         - '#Class with base "FileFinder" name is already used in "PHPStan\\File\\FileFinder", "Migrify\\ClassPresence\\Finder\\FileFinder"\. Use unique name to make classes easy to recognize#'
 
         # tests


### PR DESCRIPTION
Function `match` has param `$subkey` with/out `string` in the interface/implementing class. It works in PHP 7.2, but needs be fixed for PHP 7.1.

Running this code with PHP 7.1, I'm getting this error:

```
PHP Fatal error:  Declaration of Migrify\PhpConfigPrinter\CaseConverter\InstanceOfNestedCaseConverter::match(string $rootKey, $subKey): bool must be compatible with Migrify\PhpConfigPrinter\Contract\NestedCaseConverterInterface::match(string $rootKey, string $subKey): bool in /user/Temporary/graphql-api-php71/vendor/migrify/php-config-printer/src/CaseConverter/InstanceOfNestedCaseConverter.php on line 24
```

I couldn't add the `string` type on `InstanceOfNestedCaseConverter`, since it even asks `is_string` in the body, so I removed it from the interface.

@TomasVotruba Please check if this is right